### PR TITLE
Tweaked jpeg-js library encoder to allow for RGB image data (rather than...

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -585,7 +585,7 @@ function JPEGEncoder(quality) {
 			}
 		}
 		
-		this.encode = function(image,quality) // image data object
+		this.encode = function(image,quality,channels) // image data object
 		{
 			var time_start = new Date().getTime();
 			
@@ -745,7 +745,7 @@ function encode(imgData, qu, channels) {
   if (typeof qu === 'undefined') qu = 50;
   if (typeof channels === 'undefined') channels = 3;
   var encoder = new JPEGEncoder(qu);
-	var data = encoder.encode(imgData, qu);
+	var data = encoder.encode(imgData, qu, channels);
   return {
     data: data,
     width: imgData.width,

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -620,36 +620,35 @@ function JPEGEncoder(quality) {
 			var width = image.width;
 			var height = image.height;
 
-			var quadWidth = width*4;
-			var tripleWidth = width*3;
+			var channelWidth = width*channels;
 			
 			var x, y = 0;
 			var r, g, b;
 			var start,p, col,row,pos;
 			while(y < height){
 				x = 0;
-				while(x < quadWidth){
-				start = quadWidth * y + x;
+				while(x < channelWidth){
+				start = channelWidth * y + x;
 				p = start;
 				col = -1;
 				row = 0;
 				
 				for(pos=0; pos < 64; pos++){
 					row = pos >> 3;// /8
-					col = ( pos & 7 ) * 4; // %8
-					p = start + ( row * quadWidth ) + col;		
+					col = ( pos & 7 ) * channels; // %8
+					p = start + ( row * channelWidth ) + col;		
 					
 					if(y+row >= height){ // padding bottom
-						p-= (quadWidth*(y+1+row-height));
+						p-= (channelWidth*(y+1+row-height));
 					}
 
-					if(x+col >= quadWidth){ // padding right	
-						p-= ((x+col) - quadWidth +4)
+					if(x+col >= channelWidth){ // padding right	
+						p-= ((x+col) - channelWidth + channels)
 					}
 					
-					r = imageData[ p++ ];
-					g = imageData[ p++ ];
-					b = imageData[ p++ ];
+					r = imageData[ p ];
+					g = imageData[ p+1 ];
+					b = imageData[ p+2 ];
 					
 					
 					/* // calculate YUV values dynamically
@@ -668,9 +667,9 @@ function JPEGEncoder(quality) {
 				DCY = processDU(YDU, fdtbl_Y, DCY, YDC_HT, YAC_HT);
 				DCU = processDU(UDU, fdtbl_UV, DCU, UVDC_HT, UVAC_HT);
 				DCV = processDU(VDU, fdtbl_UV, DCV, UVDC_HT, UVAC_HT);
-				x+=32;
+				x += 8 * channels;
 				}
-				y+=8;
+				y += 8;
 			}
 			
 			
@@ -742,8 +741,9 @@ function JPEGEncoder(quality) {
 };
 module.exports = encode;
 
-function encode(imgData, qu) {
+function encode(imgData, qu, channels) {
   if (typeof qu === 'undefined') qu = 50;
+  if (typeof channels === 'undefined') channels = 3;
   var encoder = new JPEGEncoder(qu);
 	var data = encoder.encode(imgData, qu);
   return {


### PR DESCRIPTION
... assuming RGBA)

Now call with jpg.encode(imageData, quality, channels), channels defaults to 3.
