### PR TITLE
Update decoder to return Uint8Array if desired

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -969,7 +969,7 @@ var JpegImage = (function jpegImage() {
 })();
 module.exports = decode;
 
-function decode(jpegData) {
+function decode(jpegData, useTArray) {
   var arr = new Uint8Array(jpegData);
   var decoder = new JpegImage();
   decoder.parse(arr);
@@ -977,7 +977,7 @@ function decode(jpegData) {
   var image = {
     width: decoder.width,
     height: decoder.height,
-    data: new Buffer(decoder.width * decoder.height * 4)
+    data: useTArray ? new Uint8Array(decoder.width * decoder.height * 4) : new Buffer(decoder.width * decoder.height * 4)
   };
   
   decoder.copyToImageData(image);


### PR DESCRIPTION
I made this change so that this module can be used on the browser. Tested on Chrome. Made to act so that without the parameter, default functionality is unchanged.