### PR TITLE
Removed const

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -294,8 +294,8 @@ function JPEGEncoder(quality) {
 			/* Pass 1: process rows. */
 			var dataOff=0;
 			var i;
-			const I8 = 8;
-			const I64 = 64;
+			var I8 = 8;
+			var I64 = 64;
 			for (i=0; i<I8; ++i)
 			{
 				d0 = data[dataOff];
@@ -530,9 +530,9 @@ function JPEGEncoder(quality) {
 			var EOB = HTAC[0x00];
 			var M16zeroes = HTAC[0xF0];
 			var pos;
-			const I16 = 16;
-			const I63 = 63;
-			const I64 = 64;
+			var I16 = 16;
+			var I63 = 63;
+			var I64 = 64;
 			var DU_DCT = fDCTQuant(CDU, fdtbl);
 			//ZigZag reorder
 			for (var j=0;j<I64;++j) {


### PR DESCRIPTION
As noted [here](https://github.com/eugeneware/jpeg-js/blob/master/lib/encoder.js#L551), using `const` is "crazy"! 😄 

In 2017 it might be ok, but since this library should be mostly compatible with older browsers, it would be nice to remove ES6 entirely.

Came up for me because `uglifyjs` threw a fit.