### PR TITLE
Remove -*- Mode: Java; -*-

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -1,4 +1,4 @@
-/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
+/* -*- tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 /*
    Copyright 2011 notmasteryet


### PR DESCRIPTION
This seems to tell editors (and GitHub) that the code is Java but it's definitely JavaScript!

Probably good to let people know this module will 100% work in the browser. 🙂

See: [this tweet](https://twitter.com/GitHubHelp/status/879861468832968704)