### PR TITLE
fix(decoder): throw Error objects

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -109,7 +109,7 @@ var JpegImage = (function jpegImage() {
       if (bitsData == 0xFF) {
         var nextByte = data[offset++];
         if (nextByte) {
-          throw "unexpected marker: " + ((bitsData << 8) | nextByte).toString(16);
+          throw new Error("unexpected marker: " + ((bitsData << 8) | nextByte).toString(16));
         }
         // unstuff 0
       }
@@ -123,7 +123,7 @@ var JpegImage = (function jpegImage() {
         if (typeof node === 'number')
           return node;
         if (typeof node !== 'object')
-          throw "invalid huffman sequence";
+          throw new Error("invalid huffman sequence");
       }
       return null;
     }
@@ -215,7 +215,7 @@ var JpegImage = (function jpegImage() {
             }
           } else {
             if (s !== 1)
-              throw "invalid ACn encoding";
+              throw new Error("invalid ACn encoding");
             successiveACNextValue = receiveAndExtend(s);
             successiveACState = r ? 2 : 3;
           }
@@ -321,7 +321,7 @@ var JpegImage = (function jpegImage() {
       bitsCount = 0;
       marker = (data[offset] << 8) | data[offset + 1];
       if (marker < 0xFF00) {
-        throw "marker was not found";
+        throw new Error("marker was not found");
       }
 
       if (marker >= 0xFFD0 && marker <= 0xFFD7) { // RSTx
@@ -595,7 +595,7 @@ var JpegImage = (function jpegImage() {
       var huffmanTablesAC = [], huffmanTablesDC = [];
       var fileMarker = readUint16();
       if (fileMarker != 0xFFD8) { // SOI (Start of Image)
-        throw "SOI not found";
+        throw new Error("SOI not found");
       }
 
       fileMarker = readUint16();
@@ -667,7 +667,7 @@ var JpegImage = (function jpegImage() {
                   tableData[z] = readUint16();
                 }
               } else
-                throw "DQT: invalid table spec";
+                throw new Error("DQT: invalid table spec");
               quantizationTables[quantizationTableSpec & 15] = tableData;
             }
             break;
@@ -755,12 +755,12 @@ var JpegImage = (function jpegImage() {
               offset -= 3;
               break;
             }
-            throw "unknown JPEG marker " + fileMarker.toString(16);
+            throw new Error("unknown JPEG marker " + fileMarker.toString(16));
         }
         fileMarker = readUint16();
       }
       if (frames.length != 1)
-        throw "only single frame JPEGs supported";
+        throw new Error("only single frame JPEGs supported");
 
       // set each frame's components quantization table
       for (var i = 0; i < frames.length; i++) {


### PR DESCRIPTION
previously errors would not give a stack trace making it difficult to track down the source of the call to jpeg-js

