### PR TITLE
Modify nodejs-dependency

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -740,7 +740,9 @@ function JPEGEncoder(quality) {
 	init();
 	
 };
-module.exports = encode;
+if (typeof module !== undefined) {
+	module.exports = encode;
+}
 
 function encode(imgData, qu) {
   if (typeof qu === 'undefined') qu = 50;


### PR DESCRIPTION
Hi, 
I wanted to use your library for the jspdf-project. But the module.exports variable results in throwing errors in browser environments.

So I wanted to propose following change. It is not much, but I think it is efficient check to avoid the current problem. If the change is applied  we could load jpeg-js by packages.json instead putting it directly into the jspdf project.

Thank you
https://github.com/MrRio/jsPDF/pull/1489