### PR TITLE
Fixed new Buffer() deprecation due to security and usability issues

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -1100,7 +1100,7 @@ function decode(jpegData, userOpts = {}) {
       exifBuffer: decoder.exifBuffer,
       data: opts.useTArray ?
         new Uint8Array(bytesNeeded) :
-        new Buffer(bytesNeeded)
+        Buffer.alloc(bytesNeeded)
     };
     if(decoder.comments.length > 0) {
       image["comments"] = decoder.comments;

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -36,7 +36,7 @@ Basic GUI blocking jpeg encoder
 */
 
 var btoa = btoa || function(buf) {
-  return new Buffer(buf).toString('base64');
+  return Buffer.from(buf).toString('base64');
 };
 
 function JPEGEncoder(quality) {
@@ -714,7 +714,7 @@ function JPEGEncoder(quality) {
 			writeWord(0xFFD9); //EOI
 
 			if (typeof module === 'undefined') return new Uint8Array(byteout);
-      return new Buffer(byteout);
+      return Buffer.from(byteout);
 
 			var jpegDataUri = 'data:image/jpeg;base64,' + btoa(byteout.join(''));
 			


### PR DESCRIPTION
This PR fixes the new Deprecation Warning on Chromium 83 (used by Electron 9).
`DeprecationWarning: Buffer() is deprecated due to security and usability issues`

Tested it locally on my project, everything worked as expected.